### PR TITLE
Fix torrent client initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,11 @@ func main() {
 		panic(err)
 	}
 	torrentToDownload, err := client.AddMagnet(magnetLink)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+
 	// torrentToDownload, err := client.AddTorrentFromFile("./KnightsOfTheOldRepublic_dark_334_archive.torrent")
 	fmt.Println("Fetching info...")
 	// Wait for getting torrent metadata
@@ -76,6 +81,12 @@ func main() {
 	}()
 	// Create empty directory to append all files to
 	dirHash, err := ipfsClient.NewObject("unixfs-dir")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		fmt.Fprintln(os.Stderr, "Please make sure the IPFS daemon is running e.g. 'ipfs daemon --init'")
+		os.Exit(1)
+	}
+
 	for _, file := range torrentToDownload.Files() {
 		// For each file, create reader that we can use for adding to IPFS
 		reader := file.NewReader()

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"code.cloudfoundry.org/bytefmt"
 	"github.com/anacrolix/missinggo"
 	"github.com/anacrolix/torrent"
-	"github.com/anacrolix/torrent/storage"
 	api "github.com/ipfs/go-ipfs-api"
 )
 
@@ -45,8 +44,8 @@ func main() {
 
 	// Initialize torrent client
 	// TODO should be in memory-store
-	clientConfig := torrent.Config{DefaultStorage: storage.NewBoltDB(os.TempDir())}
-	client, err := torrent.NewClient(&clientConfig)
+	// clientConfig := torrent.Config{DefaultStorage: storage.NewBoltDB(os.TempDir())}
+	client, err := torrent.NewClient(nil) // Use default client config
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The anacrolix/torrent API might have changed torrent a little and torrent.Config wasn't found. They have a default client config so let's use it.
Plus I added some error handling :)